### PR TITLE
Use full name

### DIFF
--- a/autopr/database.py
+++ b/autopr/database.py
@@ -14,6 +14,10 @@ class Repository:
     removed: bool = False  # true if the repo is not in the config's filters anymore, but still has a PR open
     done: bool = False  # true if a PR has been opened and 'restart' was not called
 
+    @property
+    def full_name(self) -> str:
+        return f"{self.owner}/{self.name}"
+
 
 repository_schema = marshmallow_dataclass.class_schema(Repository)()
 

--- a/autopr/github.py
+++ b/autopr/github.py
@@ -46,7 +46,7 @@ def get_user(gh: Github) -> database.GitUser:
 def create_pr(
     gh: Github, repository: database.Repository, pr_template: config.PrTemplate
 ) -> int:
-    gh_repo = gh.get_repo(repository.name)
+    gh_repo = gh.get_repo(repository.full_name)
     gh_pr = gh_repo.create_pull(
         pr_template.title,
         pr_template.body,


### PR DESCRIPTION
We need to use either full name or ID when looking up via the API