### PR TITLE
Only show diff if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## 0.2.0
 
-- Added `--version` flag
+### Added 
+
+- Added `--version` flag (#23)
+
+### Fixed
+
+- Only show diff if it exists (#22) 
 
 ## 0.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## 0.2.0
 
-### Added 
+### Added
 
 - Added `--version` flag (#23)
 
 ### Fixed
 
-- Only show diff if it exists (#22) 
+- Only show diff if it exists (#22)
 
 ## 0.1.2
 

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -145,10 +145,10 @@ def test():
             repo.prepare_repository(WORKDIR.repos_dir, repository, cfg.pr.branch)
             repo.run_update_command(WORKDIR.repos_dir, repository, cfg.update_command)
             diff = repo.get_diff(WORKDIR.repos_dir, repository)
+            click.secho(f"Diff for repository '{repository.name}':\n{diff}")
         except CliException as e:
             error(f"Error: {e}")
 
-        click.secho(f"Diff for repository '{repository.name}':\n{diff}")
         if not click.confirm("Continue?"):
             return
 


### PR DESCRIPTION
If the script fails, `diff` would be unassigned, but still accessed.