### PR TITLE
Correct  __version__ location

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Release process
 
 1.  In `CHANGELOG.md` replace `_Unreleased_` with the release version.
-1.  In `init.py` update `__version__`.
+1.  In `autopr/__init__.py` update `__version__`.
 1.  Create a release via the GitHub UI.
     -   Set the tag to match the version
     -   Set the title to match the version


### PR DESCRIPTION
Improve release notes by clarifying `__version__` location.