### PR TITLE
Noref reset from file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     rev: v1.4.1
     hooks:
       - id: mypy
+        additional_dependencies: ['types-PyYAML==6.0.1']
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 23.7.0
     hooks:
       - id: black
         additional_dependencies: ['click==8.0.4']
@@ -9,11 +9,11 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v1.4.1
     hooks:
       - id: mypy
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.4
+- Extend `auto-pr reset` to `auto-pr reset all` and `auto-pr reset from FILE`
+  - `all` resets everything
+  - `from FILE` resets just repositories listed in the input file
+
 ## 1.0.2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ This will perform the changes to a branch on the locally cloned repository and p
 
 See `--help` for more information about other commands and their  usage.
 
+### Reset
+You can reset the list of repos in `db.json` using `auto-pr reset all`, or `auto-pr reset from FILE`
+
+When using `auto-pr reset from FILE`, the list of repos should be provided as a newline separated list of repos like `<owner>/<name>`, e.g:
+
+```text
+getyourguide/test
+getyourguide/auto-pr
+```
+
 ## Security
 
 For sensitive security matters please contact [security@getyourguide.com](mailto:security@getyourguide.com).

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -234,7 +234,7 @@ def reset_all():
 def reset_from(file):
     repos = map(lambda l: l.strip(), file.readlines())
     db = workdir.read_database(WORKDIR)
-    db.reset_using(repos)
+    db.reset_from(repos)
     workdir.write_database(WORKDIR, db)
 
 

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -229,8 +229,10 @@ def reset_all():
     click.secho("Repositories marked as not done")
 
 
-@reset.command(name="from", help="reset using a file listing of repos written as <owner>/<name>")
-@click.argument('file', type=click.File('r'))
+@reset.command(
+    name="from", help="reset using a file listing of repos written as <owner>/<name>"
+)
+@click.argument("file", type=click.File("r"))
 def reset_from(file):
     repos = map(lambda l: l.strip(), file.readlines())
     db = workdir.read_database(WORKDIR)

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -1,7 +1,7 @@
 import os
 import time
 from pathlib import Path
-from typing import List, Optional
+from typing import Iterator, List, Optional, TextIO
 
 import click
 from single_source import get_version
@@ -233,8 +233,8 @@ def reset_all():
     name="from", help="reset using a file listing of repos written as <owner>/<name>"
 )
 @click.argument("file", type=click.File("r"))
-def reset_from(file):
-    repos = map(lambda l: l.strip(), file.readlines())
+def reset_from(file: TextIO):
+    repos: Iterator[str] = map(lambda l: l.strip(), file.readlines())
     db = workdir.read_database(WORKDIR)
     db.reset_from(repos)
     workdir.write_database(WORKDIR, db)

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -214,17 +214,32 @@ def run(pull_repos: bool, push_delay: Optional[float]):
     click.secho(f"Done!", bold=True)
 
 
-@cli.command()
+@cli.group()
 def reset():
+    """Commands for resetting repos to allow for reruns"""
+    pass
+
+
+@reset.command(name="all")
+def reset_all():
     """Mark all mapped repositories as not done"""
     db = workdir.read_database(WORKDIR)
-    db.reset()
+    db.reset_all()
     workdir.write_database(WORKDIR, db)
     click.secho("Repositories marked as not done")
 
 
+@reset.command(name="from", help="reset using a file listing of repos written as <owner>/<name>")
+@click.argument('file', type=click.File('r'))
+def reset_from(file):
+    repos = map(lambda l: l.strip(), file.readlines())
+    db = workdir.read_database(WORKDIR)
+    db.reset_using(repos)
+    workdir.write_database(WORKDIR, db)
+
+
 def _print_repository_list(
-    title: str, repositories: List[database.Repository], total: int
+        title: str, repositories: List[database.Repository], total: int
 ):
     click.secho(f"{title} [{len(repositories)}/{total}]:", bold=True)
     for repository in repositories:

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -239,7 +239,7 @@ def reset_from(file):
 
 
 def _print_repository_list(
-        title: str, repositories: List[database.Repository], total: int
+    title: str, repositories: List[database.Repository], total: int
 ):
     click.secho(f"{title} [{len(repositories)}/{total}]:", bold=True)
     for repository in repositories:

--- a/autopr/database.py
+++ b/autopr/database.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 import marshmallow_dataclass
 
@@ -66,13 +66,13 @@ class Database:
             if (repository.owner, repository.name) not in new_repos:
                 repository.removed = True
 
-    def reset_from(self, selected_repos):
+    def reset_from(self, selected_repos: Iterator[str]):
         resets = {name: False for name in selected_repos}
         for repository in self.repositories:
-            id = f"{repository.owner}/{repository.name}"
-            if id in resets:
-                print(f"{id} was reset")
-                resets[id] = True
+            repo_id = f"{repository.owner}/{repository.name}"
+            if repo_id in resets:
+                print(f"{repo_id} was reset")
+                resets[repo_id] = True
                 repository.done = False
 
         for repository, done in resets.items():

--- a/autopr/database.py
+++ b/autopr/database.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Iterator, List, Optional
+from typing import Dict, Iterator, List, Optional
 
 import marshmallow_dataclass
 
@@ -67,7 +67,7 @@ class Database:
                 repository.removed = True
 
     def reset_from(self, selected_repos: Iterator[str]):
-        resets = {name: False for name in selected_repos}
+        resets: Dict[str, bool] = {name: False for name in selected_repos}
         for repository in self.repositories:
             repo_id = f"{repository.owner}/{repository.name}"
             if repo_id in resets:
@@ -75,9 +75,9 @@ class Database:
                 resets[repo_id] = True
                 repository.done = False
 
-        for repository, done in resets.items():
+        for name, done in resets.items():
             if not done:
-                print(f"{repository} was not in the database")
+                print(f"{name} was not in the database")
 
     def reset_all(self) -> None:
         for repository in self.repositories:

--- a/autopr/database.py
+++ b/autopr/database.py
@@ -66,7 +66,20 @@ class Database:
             if (repository.owner, repository.name) not in new_repos:
                 repository.removed = True
 
-    def reset(self) -> None:
+    def reset_using(self, selected_repos):
+        resets = {name: False for name in selected_repos}
+        for repository in self.repositories:
+            id = f"{repository.owner}/{repository.name}"
+            if id in resets:
+                print(f"{id} was reset")
+                resets[id] = True
+                repository.done = False
+
+        for repository, done in resets.items():
+            if not done:
+                print(f"{repository} was not in the database")
+
+    def reset_all(self) -> None:
         for repository in self.repositories:
             repository.done = False
 

--- a/autopr/database.py
+++ b/autopr/database.py
@@ -66,7 +66,7 @@ class Database:
             if (repository.owner, repository.name) not in new_repos:
                 repository.removed = True
 
-    def reset_using(self, selected_repos):
+    def reset_from(self, selected_repos):
         resets = {name: False for name in selected_repos}
         for repository in self.repositories:
             id = f"{repository.owner}/{repository.name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-pr"
-version = "1.0.3"
+version = "1.0.4"
 description = "Perform bulk updates across repositories"
 license = "Apache-2.0"
 

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -19,10 +19,33 @@ class DatabaseTest(unittest.TestCase):
         db.reset_all()
         self.assertEqual(0, len(db.repositories))
 
+    def test_reset_from_list(self):
+        repo_first = get_repository("first", done=True)
+        repo_second = get_repository("second", done=True)
+        repo_third = get_repository("second", done=False)
+
+        db = Database(
+            user=Mock(),
+            repositories=[
+                repo_first,
+                repo_second,
+                repo_third,
+            ],
+        )
+
+        self.assertTrue(db.repositories[0].done)
+        self.assertTrue(db.repositories[1].done)
+        self.assertFalse(db.repositories[2].done)
+
+        db.reset_from(selected_repos=[f"{repo_first.owner}/{repo_first.name}"])
+
+        self.assertFalse(db.repositories[0].done)
+        self.assertTrue(db.repositories[1].done)
+        self.assertFalse(db.repositories[2].done)
+
     def test_reset_non_empty(self):
-        repo_first = get_repository("first")
-        repo_first.done = True
-        repo_second = get_repository("second")
+        repo_first = get_repository("first", done=True)
+        repo_second = get_repository("second", done=False)
 
         db = Database(
             user=Mock(),

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -16,7 +16,7 @@ class DatabaseTest(unittest.TestCase):
 
     def test_reset_empty(self):
         db = Database(user=Mock(), repositories=[])
-        db.reset()
+        db.reset_all()
         self.assertEqual(0, len(db.repositories))
 
     def test_reset_non_empty(self):
@@ -35,7 +35,7 @@ class DatabaseTest(unittest.TestCase):
         self.assertTrue(db.repositories[0].done)
         self.assertFalse(db.repositories[1].done)
 
-        db.reset()
+        db.reset_all()
 
         self.assertFalse(db.repositories[0].done)
         self.assertFalse(db.repositories[1].done)

--- a/test/test_github.py
+++ b/test/test_github.py
@@ -247,7 +247,6 @@ def _get_fake_repository_tuple(
     ssh_url: str = "git@gitgitgit.com/git/repo",
     default_branch: str = "master",
 ):
-
     filter_info = FilterInfo(owner=owner, name=name, public=public, archived=archived)
     repository = Repository(
         owner=owner, name=name, ssh_url=ssh_url, default_branch=default_branch

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -50,7 +50,7 @@ def init_git_repos(wd: workdir.WorkDir, db: database.Database):
     for repository in db.repositories:
         repo_dir = wd.repos_dir / repository.name
         repo_dir.mkdir(parents=True, exist_ok=True)
-        subprocess.check_output(["git", "-C", f"{repo_dir}", "init"])
+        subprocess.check_output(["git", "-C", f"{repo_dir}", "init", "-b", "master"])
         subprocess.check_output(
             ["git", "-C", f"{repo_dir}", "config", "user.name", "Test"]
         )


### PR DESCRIPTION
## Proposed change
Allow users to reset a subset of the repositories in the `db.json` by passing an input file.

Note: I did this as a separate command mostly to keep the logic simpler, but it could also be a flag if you prefer.

## How to test the change
- set up auto-pr with some repos
- run auto pr
- set a file with the repos you want to reset as FILE
- run `auto-pr reset from FILE`
- observe only those repos are reset

## Checklist
-   [x] Tests have been added to verify that the new code works (if possible)
-   [x] Documentation has been updated to reflect changes
-   [x] `CHANGELOG.md` has been updated to reflect changes
