### PR TITLE
Provide user email as a CLI argument

### DIFF
--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -16,6 +16,7 @@ __version__ = get_version(
 
 DEFAULT_PUSH_DELAY = 30.0
 WORKDIR: workdir.WorkDir
+USER_EMAIL = None
 
 
 def main():
@@ -59,10 +60,20 @@ def _ensure_set_up(cfg: config.Config, db: database.Database):
     is_flag=True,
     help="Whether to enable debug mode or not",
 )
+@click.option(
+    "--user-email",
+    "user_email",
+    envvar="APR_USER_EMAIL",
+    type=str,
+    default=None,
+    help="User email used to publish the PRs, overrides primary email from GitHub settings."
+)
 @click.version_option(__version__, message="%(prog)s: %(version)s")
-def cli(wd_path: str, debug: bool):
+def cli(wd_path: str, debug: bool, user_email: str):
     global WORKDIR
     WORKDIR = workdir.get(wd_path)
+    global USER_EMAIL
+    USER_EMAIL = user_email
     set_debug(debug)
 
 
@@ -114,7 +125,7 @@ def pull(fetch_repo_list: bool, update_repos: bool, process_count: int):
     """Pull down repositories based on configuration"""
     cfg = workdir.read_config(WORKDIR)
     gh = github.create_github_client(cfg.credentials.api_key)
-    user = github.get_user(gh)
+    user = github.get_user(gh, USER_EMAIL)
 
     click.secho(f"Running under user '{user.name}' with email '{user.email}'")
 

--- a/autopr/github.py
+++ b/autopr/github.py
@@ -28,18 +28,21 @@ def create_github_client(api_key: str) -> Github:
     return gh
 
 
-def get_user(gh: Github) -> database.GitUser:
+def get_user(gh: Github, user_email: str) -> database.GitUser:
     gh_user = gh.get_user()
 
     login = gh_user.login  # need to do this first to trigger lazy loading
     name = gh_user.name
 
-    emails = gh_user.get_emails()
-    primary_email = None
-    for email in emails:
-        if email.primary:
-            primary_email = email.email
-            break
+    if user_email is None:
+        emails = gh_user.get_emails()
+        primary_email = None
+        for email in emails:
+            if email.primary:
+                primary_email = email.email
+                break
+    else:
+        primary_email: user_email
 
     user_name = name or login
     if user_name is None or primary_email is None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the change at a high-level.
-->
Adding an option to provide user email as a cli argument, overriding the GitHub settings. 

### Reasoning
With certain settings, it is not desired to use the primary email to commit things. Examples:
1. with email exposure protection, the commits cannot be done using primary email address but needs to be done with the noreply one.
2. different organisations require different user email to be used with the commit, so not always primary one.

## How to test the change
<!--
  Include the steps required to test the change locally if applicable.
-->

## Checklist
<!--
  Please consider the following when submitting code changes.

  Note: You can check the boxes once you submit, or put an x in the [ ]

  like [x]
-->

-   [ ] Tests have been added to verify that the new code works (if possible)
-   [ ] Documentation has been updated to reflect changes
-   [ ] `CHANGELOG.md` has been updated to reflect changes
