### PR TITLE
Pass in option to use global git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ This will generate a `db.json` file within your workdir containing a list of map
 
 This command can be run multiple times, if there are new matching repositories found they will be merged into the existing database.
 
+If you would like to use your globally set config, you can pass the option `--use-global-git-config` when pulling the repos. If you had already pulled the repos before this and you would like to change the config for those repos, you would also need to pass `--update-repos` alongside the global-git-config option when pulling.
+
 ### Test
 
 Once the `pull` command has finished setting up the work directory you can now run test to check what the changes that will be made by the script will yield.
@@ -105,6 +107,12 @@ auto-pr run
 ```
 
 This will perform the changes to a branch on the locally cloned repository and push the branch upstream with the information you provided within `config.yaml`.
+
+By default, the commits will be associated with your primary email and name, which were set on the repo level for those repos when you ran `auto-pr pull`. If you would like to use your global git config for the repos that you already pulled, you need to run pull again with:
+
+```
+auto-pr pull --update-repos --use-global-git-config
+```
 
 See `--help` for more information about other commands and their  usage.
 

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -16,6 +16,7 @@ __version__ = get_version(
 
 DEFAULT_PUSH_DELAY = 30.0
 WORKDIR: workdir.WorkDir
+USE_GLOBAL_GIT_CONFIG = False
 
 
 def main():
@@ -53,6 +54,13 @@ def _ensure_set_up(cfg: config.Config, db: database.Database):
     help="Working directory to store configuration and repositories",
 )
 @click.option(
+    "--use-global-git-config/--use-primary-email-git-config",
+    envvar="APR_USE_GLOBAL_GIT_CONFIG",
+    default=False,
+    is_flag=True,
+    help="Whether to use the already globally set git config or the primary email of the authenticated Github user",
+)
+@click.option(
     "--debug/--no-debug",
     envvar="APR_DEBUG",
     default=False,
@@ -60,9 +68,11 @@ def _ensure_set_up(cfg: config.Config, db: database.Database):
     help="Whether to enable debug mode or not",
 )
 @click.version_option(__version__, message="%(prog)s: %(version)s")
-def cli(wd_path: str, debug: bool):
+def cli(wd_path: str, use_global_git_config: bool, debug: bool):
     global WORKDIR
     WORKDIR = workdir.get(wd_path)
+    global WORKDIR
+    USE_GLOBAL_GIT_CONFIG = use_global_git_config
     set_debug(debug)
 
 

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -114,9 +114,14 @@ def init(api_key: str, ssh_key_file: str):
     "--use-global-git-config/--use-primary-email-git-config",
     default=False,
     is_flag=True,
-    help="Whether to use the already globally set git config or the primary email of the authenticated Github user. If you have already pulled the repos locally, you also need to pass --update-repos to update the git config in the repos."
+    help="Whether to use the already globally set git config or the primary email of the authenticated Github user. If you have already pulled the repos locally, you also need to pass --update-repos to update the git config in the repos.",
 )
-def pull(fetch_repo_list: bool, update_repos: bool, process_count: int, use_global_git_config: bool):
+def pull(
+    fetch_repo_list: bool,
+    update_repos: bool,
+    process_count: int,
+    use_global_git_config: bool,
+):
     """Pull down repositories based on configuration"""
     cfg = workdir.read_config(WORKDIR)
     gh = github.create_github_client(cfg.credentials.api_key)

--- a/autopr/github.py
+++ b/autopr/github.py
@@ -36,11 +36,11 @@ def get_user(gh: Github, use_global_git_config: bool = False) -> database.GitUse
     name = gh_user.name
 
     if use_global_git_config:
-        primary_email = _git_get_global_config('user.email').strip()
-        name = _git_get_global_config('user.name').strip()
+        primary_email = _git_get_global_config("user.email").strip()
+        name = _git_get_global_config("user.name").strip()
         if not name or not primary_email:
             raise CliException(
-                "You don't have a globally set Git config. " \
+                "You don't have a globally set Git config. "
                 "Please set your config with `git config --global user.email <EMAIL>` or `git config --global user.name <NAME>`"
             )
     else:

--- a/autopr/github.py
+++ b/autopr/github.py
@@ -36,9 +36,9 @@ def get_user(gh: Github, use_global_git_config: bool = False) -> database.GitUse
     name = gh_user.name
 
     if use_global_git_config:
-        primary_email = _git_get_global_config('user.email')
-        name = _git_get_global_config('user.name')
-        if not user_name or not primary_email:
+        primary_email = _git_get_global_config('user.email').strip()
+        name = _git_get_global_config('user.name').strip()
+        if not name or not primary_email:
             raise CliException(
                 "You don't have a globally set Git config. " \
                 "Please set your config with `git config --global user.email <EMAIL>` or `git config --global user.name <NAME>`"

--- a/autopr/github.py
+++ b/autopr/github.py
@@ -3,8 +3,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Tuple
 
-from . import USE_GLOBAL_GIT_CONFIG
-
 from github import Github
 from github.PullRequest import PullRequest
 
@@ -31,13 +29,13 @@ def create_github_client(api_key: str) -> Github:
     return gh
 
 
-def get_user(gh: Github) -> database.GitUser:
+def get_user(gh: Github, use_global_git_config: bool = False) -> database.GitUser:
     gh_user = gh.get_user()
 
     login = gh_user.login  # need to do this first to trigger lazy loading
     name = gh_user.name
 
-    if USE_GLOBAL_GIT_CONFIG:
+    if use_global_git_config:
         primary_email = _git_get_global_config('user.email')
         name = _git_get_global_config('user.name')
         if not user_name or not primary_email:

--- a/autopr/repo.py
+++ b/autopr/repo.py
@@ -229,7 +229,7 @@ def _git_config(repo_dir: Path, key: str, value: str) -> None:
     run_cmd(["git", "-C", f"{repo_dir}", "config", key, value])
 
 
-def _git_get_global_config(key: str) -> None:
+def _git_get_global_config(key: str) -> str:
     return run_cmd(["git", "config", "--global", key])
 
 

--- a/autopr/repo.py
+++ b/autopr/repo.py
@@ -230,7 +230,7 @@ def _git_config(repo_dir: Path, key: str, value: str) -> None:
 
 
 def _git_get_global_config(key: str) -> None:
-    return run_cmd(["git", "--global", "config", key])
+    return run_cmd(["git", "config", "--global", key])
 
 
 def _git_staged_diff(repo_dir: Path) -> str:

--- a/autopr/repo.py
+++ b/autopr/repo.py
@@ -229,6 +229,10 @@ def _git_config(repo_dir: Path, key: str, value: str) -> None:
     run_cmd(["git", "-C", f"{repo_dir}", "config", key, value])
 
 
+def _git_get_global_config(key: str) -> None:
+    return run_cmd(["git", "--global", "config", key])
+
+
 def _git_staged_diff(repo_dir: Path) -> str:
     return run_cmd(
         ["git", "-c", "color.ui=always", "-C", f"{repo_dir}", "diff", "--staged"]


### PR DESCRIPTION
## Proposed change
With this change, one can pass `--use-global-git-config` to the `auto-pr pull` command so that the default behavior to use the primary email of the authenticated Github user is overridden by using the global `git` config.

If the repos have already been pulled and you would like to run the auto-pr with your global config, you would need to run `auto-pr pull --update-repos --use-global-git-config` before running `auto-pr run` to override the config of your newly pulled repos.

## How to test the change

```
poetry install
poetry run auto-pr -w <PATH_TO_YOUR_AUTOPR_CONFIG> pull --use-global-git-config --update-repos
```
in order to change the config on your already pulled repos

## Checklist
<!--
  Please consider the following when submitting code changes.

  Note: You can check the boxes once you submit, or put an x in the [ ]

  like [x]
-->

-   [ ] Tests have been added to verify that the new code works (if possible)
-   [ ] Documentation has been updated to reflect changes
-   [ ] `CHANGELOG.md` has been updated to reflect changes
