### PR TITLE
DEN-4516 Add option to exclude missing PRs section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## _Unreleased_
+## 1.0.7
 - Add `--exclude-missing` when running `auto-pr status`
   - Allows you to remove the `Missing PRs` section from the output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## _Unreleased_
+- Add `--exclude-missing` when running `auto-pr status`
+  - Allows you to remove the `Missing PRs` section from the output
+
 ## 1.0.6
 - Add `--use-global-git-config` when running `auto-pr pull`
   - Allows you to use the globally set git config in your device instead of using the authenticated Github user's primary email

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -266,7 +266,13 @@ def _print_repository_list(
 
 
 @cli.command()
-def status():
+@click.option(
+    "--exclude-missing/--include-missing",
+    default=True,
+    is_flag=True,
+    help="Whether the `Missing PRs` section should be shown.",
+)
+def status(exclude_missing: bool):
     cfg = workdir.read_config(WORKDIR)
     db = workdir.read_database(WORKDIR)
     gh = github.create_github_client(cfg.credentials.api_key)
@@ -300,7 +306,8 @@ def status():
     _print_repository_list("Merged PRs", pr_merged, total)
     _print_repository_list("Closed PRs", pr_closed, total)
     _print_repository_list("Open PRs", pr_open, total)
-    _print_repository_list("Missing PRs", pr_missing, total)
+    if not exclude_missing:
+        _print_repository_list("Missing PRs", pr_missing, total)
 
 
 def _set_all_pull_requests_state(state: github.PullRequestState):

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -268,9 +268,9 @@ def _print_repository_list(
 @cli.command()
 @click.option(
     "--exclude-missing/--include-missing",
-    default=True,
+    default=False,
     is_flag=True,
-    help="Whether the `Missing PRs` section should be shown.",
+    help="Whether the `Missing PRs` section should be excluded from status.",
 )
 def status(exclude_missing: bool):
     cfg = workdir.read_config(WORKDIR)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-pr"
-version = "1.0.6"
+version = "1.0.7"
 description = "Perform bulk updates across repositories"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Proposed change
Add an option to exclude `Missing PRs` section from the `status` command.

## How to test the change
<!--
  Include the steps required to test the change locally if applicable.
-->
Run `auto-pr status --exclude-missing` 

## Checklist
<!--
  Please consider the following when submitting code changes.

  Note: You can check the boxes once you submit, or put an x in the [ ]

  like [x]
-->

-   [ ] Tests have been added to verify that the new code works (if possible)
-   [x] Documentation has been updated to reflect changes
-   [x] `CHANGELOG.md` has been updated to reflect changes
