### PR TITLE
Support reading GitHub token from env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.8
+- Support providing GitHub Token via `APR_API_KEY` env var instead of `config.yaml`
+
 ## 1.0.7
 - Add `--exclude-missing` when running `auto-pr status`
   - Allows you to remove the `Missing PRs` section from the output

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ update_command:
   - my-file
 ```
 
+If you wish to keep your API Key outside of `config.yaml`, set the env var `APR_API_KEY` with your GitHub Token
+
 ### Repositories
 
 You can define the list of repositories to pull and build into the database to update using a list of rules.

--- a/autopr/config.py
+++ b/autopr/config.py
@@ -15,11 +15,10 @@ FILTER_MODE_REMOVE = "remove"
 FILTER_VISIBILITY_PUBLIC = "public"
 FILTER_VISIBILITY_PRIVATE = "private"
 
-
 @dataclass
 class Credentials:
     ssh_key_file: str
-    api_key: str = environ.get("APR_API_KEY", "")
+    api_key: str = field(default_factory=( lambda: environ.get('APR_API_KEY', '')))
 
 
 CREDENTIALS_SCHEMA = marshmallow_dataclass.class_schema(Credentials)()

--- a/autopr/config.py
+++ b/autopr/config.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import List, Optional
+from os import environ
 
 import marshmallow_dataclass
 
@@ -17,8 +18,8 @@ FILTER_VISIBILITY_PRIVATE = "private"
 
 @dataclass
 class Credentials:
-    api_key: str
     ssh_key_file: str
+    api_key: str = environ.get("APR_API_KEY", "")
 
 
 CREDENTIALS_SCHEMA = marshmallow_dataclass.class_schema(Credentials)()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-pr"
-version = "1.0.7"
+version = "1.0.8"
 description = "Perform bulk updates across repositories"
 license = "Apache-2.0"
 

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -5,6 +5,7 @@ from test.test_utils import (
     run_cli,
     simple_test_config,
     simple_test_database,
+    env_var_token_test_config,
 )
 from typing import Dict, List, Optional
 from unittest.mock import Mock, patch
@@ -43,3 +44,19 @@ def test_create_files(_create_github_client: Mock, tmp_path):
         db=db,
     )
     print(result.output)
+
+@patch("autopr.repo.run_cmd", new=_test_cmd)
+@patch("autopr.github.create_github_client")
+def test_api_key_env_var(_create_github_client: Mock, monkeypatch, tmp_path):
+    monkeypatch.setenv('APR_API_KEY', 'env_var_test')
+    wd = workdir.WorkDir(Path(tmp_path))
+    db = simple_test_database()
+    init_git_repos(wd, db)
+    result = run_cli(
+        wd,
+        ["run"],
+        cfg=env_var_token_test_config(),
+        db=db,
+    )
+
+    assert _create_github_client.call_args_list[0][0][0] == 'env_var_test', f'wrong api_key used for create_github_client: {_create_github_client.call_args_list}'

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -71,6 +71,12 @@ def simple_test_config() -> config.Config:
     cmd = ["bash", "-c", "echo 'test' > testfile.txt"]
     return config.Config(credentials=credentials, pr=pr, update_command=cmd)
 
+def env_var_token_test_config() -> config.Config:
+    credentials = config.Credentials(ssh_key_file="test")
+    pr = config.PrTemplate()
+    cmd = ["bash", "-c", "echo 'test' > testfile.txt"]
+    return config.Config(credentials=credentials, pr=pr, update_command=cmd)
+
 
 def simple_test_database() -> database.Database:
     repo = database.Repository(


### PR DESCRIPTION
## Proposed change

I would like to share my config.yaml and update scripts in a git repo, so I need a way to supply the GitHub token outside of config.yaml

This solution felt natural to me, but I would be willing to take a second pass utilizing a credentials file instead. (or any other preferred solution!)

Thanks for this great tool!

## How to test the change

I tested manually by exporting the env var and successfully building a `db.json` with `auto-pr pull`

## Checklist
<!--
  Please consider the following when submitting code changes.

  Note: You can check the boxes once you submit, or put an x in the [ ]

  like [x]
-->

-   [x] Tests have been added to verify that the new code works (if possible)
-   [x] Documentation has been updated to reflect changes
-   [x] `CHANGELOG.md` has been updated to reflect changes
