### PR TITLE
Revert documentation changes and allow passing api key to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.9
+
+- Add `--api-key` flag to `auto-pr run` command
+  - Allows you to pass the API key as a flag (or as the env APR_API_KEY variable) instead of storing
+  it in the configuration file
+
 ## 1.0.7
 - Add `--exclude-missing` when running `auto-pr status`
   - Allows you to remove the `Missing PRs` section from the output

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ update_command:
   - my-file
 ```
 
+If you wish to keep your API Key outside of `config.yaml`, set the env var `APR_API_KEY` with your GitHub Token
+
 ### Repositories
 
 You can define the list of repositories to pull and build into the database to update using a list of rules.

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -197,9 +197,18 @@ def test(pull_repos: bool):
     default=DEFAULT_PUSH_DELAY,
     help="Delay in seconds between pushing changes to repositories",
 )
-def run(pull_repos: bool, push_delay: Optional[float]):
+@click.option(
+    "--api-key",
+    envvar="APR_API_KEY",
+    required=False,
+    hide_input=True,
+    help="The GitHub API key to use if not statically configured",
+)
+def run(pull_repos: bool, push_delay: Optional[float], api_key: Optional[str]):
     """Run update logic and create pull requests if changes made"""
     cfg = workdir.read_config(WORKDIR)
+    if api_key is not None:
+        cfg.credentials.api_key = api_key
     db = workdir.read_database(WORKDIR)
     _ensure_set_up(cfg, db)
     gh = github.create_github_client(cfg.credentials.api_key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-pr"
-version = "1.0.7"
+version = "1.0.9"
 description = "Perform bulk updates across repositories"
 license = "Apache-2.0"
 

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -5,6 +5,7 @@ from test.test_utils import (
     run_cli,
     simple_test_config,
     simple_test_database,
+    env_var_token_test_config,
 )
 from typing import Dict, List, Optional
 from unittest.mock import Mock, patch
@@ -48,7 +49,6 @@ def test_create_files(_create_github_client: Mock, tmp_path):
 @patch("autopr.repo.run_cmd", new=_test_cmd)
 @patch("autopr.github.create_github_client")
 def test_api_key_env_var(_create_github_client: Mock, monkeypatch, tmp_path):
-    monkeypatch.setenv("APR_API_KEY", "env_var_test")
     wd = workdir.WorkDir(Path(tmp_path))
     db = simple_test_database()
     init_git_repos(wd, db)
@@ -56,6 +56,7 @@ def test_api_key_env_var(_create_github_client: Mock, monkeypatch, tmp_path):
         wd,
         ["run"],
         cfg=env_var_token_test_config(),
+        env={"APR_API_KEY": "env_var_test"},
         db=db,
     )
     assert (

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -43,3 +43,21 @@ def test_create_files(_create_github_client: Mock, tmp_path):
         db=db,
     )
     print(result.output)
+
+
+@patch("autopr.repo.run_cmd", new=_test_cmd)
+@patch("autopr.github.create_github_client")
+def test_api_key_env_var(_create_github_client: Mock, monkeypatch, tmp_path):
+    monkeypatch.setenv("APR_API_KEY", "env_var_test")
+    wd = workdir.WorkDir(Path(tmp_path))
+    db = simple_test_database()
+    init_git_repos(wd, db)
+    result = run_cli(
+        wd,
+        ["run"],
+        cfg=env_var_token_test_config(),
+        db=db,
+    )
+    assert (
+        _create_github_client.call_args_list[0][0][0] == "env_var_test"
+    ), f"wrong api_key used for create_github_client: {_create_github_client.call_args_list}"

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -1,11 +1,11 @@
 import subprocess
 from pathlib import Path
 from test.test_utils import (
+    env_var_token_test_config,
     init_git_repos,
     run_cli,
     simple_test_config,
     simple_test_database,
-    env_var_token_test_config,
 )
 from typing import Dict, List, Optional
 from unittest.mock import Mock, patch

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -12,6 +12,7 @@ def run_cli(
     cmd: List[str],
     cfg: Optional[config.Config] = None,
     db: Optional[database.Database] = None,
+    env: Optional[dict]=None,
     should_fail: bool = False,
 ) -> Result:
     if cfg:
@@ -20,10 +21,11 @@ def run_cli(
         workdir.write_database(wd, db)
 
     runner = CliRunner()
+    env = env or {}
     result = runner.invoke(
         cli,
         cmd,
-        env={"APR_WORKDIR": f"{wd.location}", "APR_DEBUG": "1"},
+        env={"APR_WORKDIR": f"{wd.location}", "APR_DEBUG": "1", **env},
         catch_exceptions=True,
     )
     if result.exception is not None:
@@ -96,3 +98,10 @@ def get_repository(
         removed=removed,
         done=done,
     )
+
+
+def env_var_token_test_config() -> config.Config:
+    credentials = config.Credentials(api_key="", ssh_key_file="test")
+    pr = config.PrTemplate()
+    cmd = ["bash", "-c", "echo 'test' > testfile.txt"]
+    return config.Config(credentials=credentials, pr=pr, update_command=cmd)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -12,7 +12,7 @@ def run_cli(
     cmd: List[str],
     cfg: Optional[config.Config] = None,
     db: Optional[database.Database] = None,
-    env: Optional[dict]=None,
+    env: Optional[dict] = None,
     should_fail: bool = False,
 ) -> Result:
     if cfg:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the change at a high-level.
-->
- allow setting APR_API_KEY as env (or passing using `--api-key`) to `autopr run`


## How to test the change
<!--
  Include the steps required to test the change locally if applicable.
-->

## Checklist
<!--
  Please consider the following when submitting code changes.

  Note: You can check the boxes once you submit, or put an x in the [ ]

  like [x]
-->

-   [x] Tests have been added to verify that the new code works (if possible)
-   [ ] Documentation has been updated to reflect changes
-   [ ] `CHANGELOG.md` has been updated to reflect changes
