### PR TITLE
Use new Github API method for PR creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.11
+
+- Fix Github API call error
+
 ## 1.0.10
 
 - Fix Github API auth issue by upgrading `PyGithub` lib

--- a/autopr/github.py
+++ b/autopr/github.py
@@ -66,10 +66,10 @@ def create_pr(
 ) -> PullRequest:
     gh_repo = gh.get_repo(repository.full_name)
     pull_request = gh_repo.create_pull(
-        pr_template.title,
-        pr_template.body,
-        repository.default_branch,
-        pr_template.branch,
+        base=repository.default_branch,
+        head=pr_template.branch,
+        title=pr_template.title,
+        body=pr_template.body,
         maintainer_can_modify=True,
     )
     return pull_request


### PR DESCRIPTION
## Proposed change
Use new Github API for PR creation to fix the error:
```
TypeError: Repository.create_pull() takes 3 positional arguments but 5 positional arguments (and 1 keyword-only argument) were given
```

## How to test the change
<!--
  Include the steps required to test the change locally if applicable.
-->

## Checklist
<!--
  Please consider the following when submitting code changes.

  Note: You can check the boxes once you submit, or put an x in the [ ]

  like [x]
-->

-   [ ] Tests have been added to verify that the new code works (if possible)
-   [ ] Documentation has been updated to reflect changes
-   [x] `CHANGELOG.md` has been updated to reflect changes
