### PR TITLE
Add draft option to PR template and update creation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+
+- Add `draft` PR property to allows you to create draft PRs instead of regular PRs
+
 ## 1.0.11
 
 - Fix Github API call error

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ pr:
   branch: auto-pr # The branch name to use when making changes
   message: Replace default pipelines with modules # Commit message
   title: 'My awesome change' # Title of the PR
+  draft: True # Whether to create the PR as a draft
 repositories: # Rules that define what repos to update
   - mode: add
     match_owner: <org/user>

--- a/autopr/config.py
+++ b/autopr/config.py
@@ -30,6 +30,7 @@ class PrTemplate:
     message: str = DEFAULT_PR_MESSAGE
     branch: str = DEFAULT_PR_BRANCH
     body: str = DEFAULT_PR_BODY
+    draft: bool = False
 
 
 PR_TEMPLATE_SCHEMA = marshmallow_dataclass.class_schema(PrTemplate)()

--- a/autopr/github.py
+++ b/autopr/github.py
@@ -71,6 +71,7 @@ def create_pr(
         title=pr_template.title,
         body=pr_template.body,
         maintainer_can_modify=True,
+        draft=pr_template.draft,
     )
     return pull_request
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,148 @@
+import unittest
+
+from autopr.config import PR_TEMPLATE_SCHEMA, PrTemplate
+
+
+class TestPrTemplate(unittest.TestCase):
+    def test_pr_template_default_draft_false(self):
+        """Test that PrTemplate defaults draft to False"""
+        template = PrTemplate()
+        self.assertFalse(template.draft)
+
+    def test_pr_template_explicit_draft_true(self):
+        """Test that PrTemplate can be created with draft=True"""
+        template = PrTemplate(draft=True)
+        self.assertTrue(template.draft)
+
+    def test_pr_template_explicit_draft_false(self):
+        """Test that PrTemplate can be explicitly set to draft=False"""
+        template = PrTemplate(draft=False)
+        self.assertFalse(template.draft)
+
+    def test_pr_template_schema_serialization_default(self):
+        """Test that PR_TEMPLATE_SCHEMA correctly serializes default template"""
+        template = PrTemplate()
+        data = PR_TEMPLATE_SCHEMA.dump(template)
+
+        self.assertIn("draft", data)
+        self.assertFalse(data["draft"])
+
+        # Check other default values are present
+        self.assertEqual(data["title"], "Automatically generated PR")
+        self.assertEqual(data["message"], "Automatically generated commit")
+        self.assertEqual(data["branch"], "autopr")
+        self.assertEqual(data["body"], "This is an automatically generated PR")
+
+    def test_pr_template_schema_serialization_draft_true(self):
+        """Test that PR_TEMPLATE_SCHEMA correctly serializes template with draft=True"""
+        template = PrTemplate(draft=True)
+        data = PR_TEMPLATE_SCHEMA.dump(template)
+
+        self.assertIn("draft", data)
+        self.assertTrue(data["draft"])
+
+    def test_pr_template_schema_deserialization_draft_false(self):
+        """Test that PR_TEMPLATE_SCHEMA correctly deserializes draft=False"""
+        data = {
+            "title": "Test PR",
+            "message": "Test message",
+            "branch": "test-branch",
+            "body": "Test body",
+            "draft": False,
+        }
+
+        template = PR_TEMPLATE_SCHEMA.load(data)
+
+        self.assertEqual(template.title, "Test PR")
+        self.assertEqual(template.message, "Test message")
+        self.assertEqual(template.branch, "test-branch")
+        self.assertEqual(template.body, "Test body")
+        self.assertFalse(template.draft)
+
+    def test_pr_template_schema_deserialization_draft_true(self):
+        """Test that PR_TEMPLATE_SCHEMA correctly deserializes draft=True"""
+        data = {
+            "title": "Test PR",
+            "message": "Test message",
+            "branch": "test-branch",
+            "body": "Test body",
+            "draft": True,
+        }
+
+        template = PR_TEMPLATE_SCHEMA.load(data)
+
+        self.assertEqual(template.title, "Test PR")
+        self.assertEqual(template.message, "Test message")
+        self.assertEqual(template.branch, "test-branch")
+        self.assertEqual(template.body, "Test body")
+        self.assertTrue(template.draft)
+
+    def test_pr_template_schema_deserialization_missing_draft(self):
+        """Test that PR_TEMPLATE_SCHEMA handles missing draft field gracefully"""
+        data = {
+            "title": "Test PR",
+            "message": "Test message",
+            "branch": "test-branch",
+            "body": "Test body"
+            # Intentionally omitting draft field
+        }
+
+        template = PR_TEMPLATE_SCHEMA.load(data)
+
+        self.assertEqual(template.title, "Test PR")
+        self.assertEqual(template.message, "Test message")
+        self.assertEqual(template.branch, "test-branch")
+        self.assertEqual(template.body, "Test body")
+        self.assertFalse(template.draft)  # Should default to False
+
+    def test_pr_template_schema_roundtrip_draft_false(self):
+        """Test serialize -> deserialize roundtrip with draft=False"""
+        original = PrTemplate(
+            title="Test PR",
+            message="Test message",
+            branch="test-branch",
+            body="Test body",
+            draft=False,
+        )
+
+        # Serialize
+        data = PR_TEMPLATE_SCHEMA.dump(original)
+
+        # Deserialize
+        restored = PR_TEMPLATE_SCHEMA.load(data)
+
+        # Verify all fields match
+        self.assertEqual(original.title, restored.title)
+        self.assertEqual(original.message, restored.message)
+        self.assertEqual(original.branch, restored.branch)
+        self.assertEqual(original.body, restored.body)
+        self.assertEqual(original.draft, restored.draft)
+        self.assertFalse(restored.draft)
+
+    def test_pr_template_schema_roundtrip_draft_true(self):
+        """Test serialize -> deserialize roundtrip with draft=True"""
+        original = PrTemplate(
+            title="Draft PR",
+            message="Draft message",
+            branch="draft-branch",
+            body="Draft body",
+            draft=True,
+        )
+
+        # Serialize
+        data = PR_TEMPLATE_SCHEMA.dump(original)
+
+        # Deserialize
+        restored = PR_TEMPLATE_SCHEMA.load(data)
+
+        # Verify all fields match
+        self.assertEqual(original.title, restored.title)
+        self.assertEqual(original.message, restored.message)
+        self.assertEqual(original.branch, restored.branch)
+        self.assertEqual(original.body, restored.body)
+        self.assertEqual(original.draft, restored.draft)
+        self.assertTrue(restored.draft)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Proposed change
Add a draft configuration flag that allows users to open pull requests as drafts. This improves usability by letting auto-pr users prepare rollout changes without notifying the repository owner.

## How to test the change
<!--
  Include the steps required to test the change locally if applicable.
-->

## Checklist
<!--
  Please consider the following when submitting code changes.

  Note: You can check the boxes once you submit, or put an x in the [ ]

  like [x]
-->

-   [x] Tests have been added to verify that the new code works (if possible)
-   [x] Documentation has been updated to reflect changes
-   [x] `CHANGELOG.md` has been updated to reflect changes
