### PR TITLE
Add system environment variable support for the sensitive config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.2.0
+
+- Add environment variable expansion support in `config.yaml` for credentials
+  - Use `${VAR_NAME}` syntax to reference system environment variables
+  - Supports expansion in `api_key` and `ssh_key_file` fields
+  - Enables keeping sensitive credentials out of configuration files
+  - Clear error messages when referenced environment variables are not set
+
 ## 1.1.0
 
 - Add `draft` PR property to allows you to create draft PRs instead of regular PRs

--- a/README.md
+++ b/README.md
@@ -60,7 +60,33 @@ update_command:
   - my-file
 ```
 
-If you wish to keep your API Key outside of `config.yaml`, set the env var `APR_API_KEY` with your GitHub Token
+#### Using Environment Variables for Credentials
+
+To avoid storing credentials in plain text within `config.yaml`, you can use environment variable expansion with the `${VAR_NAME}` syntax:
+
+```yaml
+credentials:
+  api_key: ${GITHUB_API_KEY}
+  ssh_key_file: ${HOME}/.ssh/id_rsa
+```
+
+Then set the environment variables before running auto-pr:
+
+```bash
+export GITHUB_API_KEY=ghp_your_token_here
+export HOME=/home/username
+auto-pr pull
+```
+
+Environment variables can be used in multiple ways:
+
+- **Full replacement**: `api_key: ${GITHUB_API_KEY}`
+- **Embedded in paths**: `ssh_key_file: ${HOME}/.ssh/id_rsa`
+- **Multiple variables**: `ssh_key_file: ${USER_HOME}/${KEY_DIR}/id_rsa`
+
+If a referenced environment variable is not set, auto-pr will display a clear error message indicating which variable is missing.
+
+Alternatively, if you wish to keep your API Key outside of `config.yaml` without modifying the config file, you can set the env var `APR_API_KEY` with your GitHub Token
 
 ### Repositories
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-pr"
-version = "1.1.0"
+version = "1.2.0"
 description = "Perform bulk updates across repositories"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Proposed change

This PR adds support for environment variable expansion in the `config.yaml` file, allowing users to reference system environment variables using the `${VAR_NAME}` syntax. This is particularly useful for keeping sensitive credentials like API keys and SSH key paths out of configuration files.

## Configuration Examples

### Basic Usage

Instead of storing credentials directly in `config.yaml`:

```yaml
credentials:
  api_key: ${GITHUB_API_KEY}
  ssh_key_file: ${HOME}/.ssh/id_rsa
```

Then set environment variables before running:

```bash
export GITHUB_API_KEY=ghp_your_token_here
export HOME=/home/username
auto-pr pull
```

## Checklist

-   [x] Tests have been added to verify that the new code works (if possible)
-   [x] Documentation has been updated to reflect changes
-   [x] `CHANGELOG.md` has been updated to reflect changes
