### PR TITLE
Add configurable work dir to optimize the repo clone

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: mypy
         additional_dependencies: ['types-PyYAML==6.0.1']
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Add custom repositories directory support
+  - Add `custom_repos_dir` configuration option to use existing cloned repositories
+  - Add `--repos-dir` CLI flag to override repository directory location
+  - Supports environment variable expansion with `${VAR_NAME}` syntax
+  - Useful for organizations with >1k repositories to avoid duplicating disk space
+  - Priority order: CLI flag > config file > default `repos/` subdirectory
+
 ## 1.2.0
 
 - Add environment variable expansion support in `config.yaml` for credentials

--- a/README.md
+++ b/README.md
@@ -88,6 +88,56 @@ If a referenced environment variable is not set, auto-pr will display a clear er
 
 Alternatively, if you wish to keep your API Key outside of `config.yaml` without modifying the config file, you can set the env var `APR_API_KEY` with your GitHub Token
 
+#### Using a Custom Repositories Directory
+
+By default, auto-pr clones repositories into a `repos/` subdirectory within your working directory. If you already have repositories cloned locally (e.g., >1k repositories), you can configure auto-pr to use your existing directory instead:
+
+**Option 1: Config file**
+
+Add `custom_repos_dir` to your `config.yaml`:
+
+```yaml
+credentials:
+  api_key: ${GITHUB_API_KEY}
+  ssh_key_file: ${HOME}/.ssh/id_rsa
+pr:
+  title: 'My awesome change'
+  branch: auto-pr
+  message: Update dependencies
+  body: Automated update
+  draft: false
+repositories:
+  - mode: add
+    match_owner: myorg
+update_command:
+  - echo
+  - "Hello"
+custom_repos_dir: /path/to/existing/repos  # Point to your existing cloned repos
+```
+
+The `custom_repos_dir` field supports environment variable expansion:
+
+```yaml
+custom_repos_dir: ${HOME}/all-my-repos
+```
+
+**Option 2: CLI flag**
+
+Use the `--repos-dir` option when running commands:
+
+```bash
+auto-pr --repos-dir=/path/to/existing/repos pull
+auto-pr --repos-dir=/path/to/existing/repos test
+auto-pr --repos-dir=/path/to/existing/repos run
+```
+
+The CLI option takes precedence over the config file setting.
+
+**Important notes:**
+- The custom repos directory must exist before running `auto-pr init`
+- auto-pr will use the existing cloned repositories and apply its cleanup operations as normal
+- This is useful for organizations with many repositories to avoid duplicating disk space
+
 ### Repositories
 
 You can define the list of repositories to pull and build into the database to update using a list of rules.

--- a/autopr/__init__.py
+++ b/autopr/__init__.py
@@ -53,6 +53,12 @@ def _ensure_set_up(cfg: config.Config, db: database.Database):
     help="Working directory to store configuration and repositories",
 )
 @click.option(
+    "--repos-dir",
+    "repos_dir_path",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, readable=True),
+    help="Custom directory containing cloned repositories",
+)
+@click.option(
     "--debug/--no-debug",
     envvar="APR_DEBUG",
     default=False,
@@ -60,9 +66,10 @@ def _ensure_set_up(cfg: config.Config, db: database.Database):
     help="Whether to enable debug mode or not",
 )
 @click.version_option(__version__, message="%(prog)s: %(version)s")
-def cli(wd_path: str, debug: bool):
+def cli(wd_path: str, repos_dir_path: Optional[str], debug: bool):
     global WORKDIR
-    WORKDIR = workdir.get(wd_path)
+    custom_repos = Path(repos_dir_path) if repos_dir_path else None
+    WORKDIR = workdir.get(wd_path, custom_repos_dir=custom_repos)
     set_debug(debug)
 
 

--- a/test/test_workdir_custom_repos.py
+++ b/test/test_workdir_custom_repos.py
@@ -1,0 +1,208 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from autopr import config, workdir
+from autopr.util import CliException
+
+
+def test_workdir_custom_repos_dir_via_constructor(tmp_path):
+    """Test WorkDir with custom_repos_dir set via constructor"""
+    custom_dir = Path(tmp_path) / "custom-repos"
+    custom_dir.mkdir()
+
+    wd = workdir.WorkDir(Path(tmp_path), custom_repos_dir=custom_dir)
+    assert wd.repos_dir == custom_dir
+
+
+def test_workdir_custom_repos_dir_via_config(tmp_path):
+    """Test WorkDir with custom_repos_dir set via config file"""
+    custom_dir = Path(tmp_path) / "custom-repos"
+    custom_dir.mkdir()
+
+    # Create a config with custom_repos_dir
+    wd = workdir.WorkDir(Path(tmp_path))
+    credentials = config.Credentials(api_key="test", ssh_key_file="test_key")
+    pr = config.PrTemplate()
+    cfg = config.Config(
+        credentials=credentials, pr=pr, custom_repos_dir=str(custom_dir)
+    )
+    workdir.write_config(wd, cfg)
+
+    # Read it back and verify repos_dir
+    assert wd.repos_dir == custom_dir
+
+
+def test_workdir_priority_cli_over_config(tmp_path):
+    """Test that CLI option takes precedence over config file"""
+    cli_custom_dir = Path(tmp_path) / "cli-repos"
+    cli_custom_dir.mkdir()
+    config_custom_dir = Path(tmp_path) / "config-repos"
+    config_custom_dir.mkdir()
+
+    # Create a config with custom_repos_dir
+    wd_setup = workdir.WorkDir(Path(tmp_path))
+    credentials = config.Credentials(api_key="test", ssh_key_file="test_key")
+    pr = config.PrTemplate()
+    cfg = config.Config(
+        credentials=credentials, pr=pr, custom_repos_dir=str(config_custom_dir)
+    )
+    workdir.write_config(wd_setup, cfg)
+
+    # Create WorkDir with CLI custom_repos_dir
+    wd = workdir.WorkDir(Path(tmp_path), custom_repos_dir=cli_custom_dir)
+    assert wd.repos_dir == cli_custom_dir
+    assert wd.repos_dir != config_custom_dir
+
+
+def test_workdir_default_behavior(tmp_path):
+    """Test default behavior when no custom_repos_dir is specified"""
+    wd = workdir.WorkDir(Path(tmp_path))
+    expected_default = Path(tmp_path) / "repos"
+    assert wd.repos_dir == expected_default
+
+
+def test_init_validates_custom_repos_dir_exists(tmp_path):
+    """Test init fails with clear error when custom repos dir doesn't exist"""
+    nonexistent_dir = Path(tmp_path) / "nonexistent-repos"
+
+    wd = workdir.WorkDir(Path(tmp_path), custom_repos_dir=nonexistent_dir)
+    credentials = config.Credentials(api_key="test", ssh_key_file="test_key")
+
+    with pytest.raises(CliException) as exc_info:
+        workdir.init(wd, credentials)
+
+    assert str(nonexistent_dir) in str(exc_info.value)
+    assert "does not exist" in str(exc_info.value)
+
+
+def test_init_success_with_existing_custom_repos_dir(tmp_path):
+    """Test init succeeds when custom repos dir exists"""
+    custom_dir = Path(tmp_path) / "existing-repos"
+    custom_dir.mkdir()
+
+    test_key = Path(tmp_path) / "test_key"
+    test_key.touch()
+
+    wd = workdir.WorkDir(Path(tmp_path), custom_repos_dir=custom_dir)
+    credentials = config.Credentials(api_key="test", ssh_key_file=str(test_key))
+
+    # Should not raise
+    workdir.init(wd, credentials)
+
+    # Verify custom dir still exists and was not modified
+    assert custom_dir.exists()
+    assert custom_dir.is_dir()
+
+
+def test_init_creates_default_repos_dir(tmp_path):
+    """Test init creates default repos dir when no custom dir specified"""
+    test_key = Path(tmp_path) / "test_key"
+    test_key.touch()
+
+    wd = workdir.WorkDir(Path(tmp_path))
+    credentials = config.Credentials(api_key="test", ssh_key_file=str(test_key))
+
+    default_repos_dir = Path(tmp_path) / "repos"
+    assert not default_repos_dir.exists()
+
+    workdir.init(wd, credentials)
+
+    # Verify default repos dir was created
+    assert default_repos_dir.exists()
+    assert default_repos_dir.is_dir()
+
+
+def test_config_custom_repos_dir_env_var_expansion(tmp_path):
+    """Test environment variable expansion in custom_repos_dir"""
+    # Set environment variable
+    custom_repos_base = Path(tmp_path) / "my-repos"
+    custom_repos_base.mkdir()
+    os.environ["TEST_CUSTOM_REPOS_DIR"] = str(custom_repos_base)
+
+    try:
+        # Create config with env var
+        wd = workdir.WorkDir(Path(tmp_path))
+        credentials = config.Credentials(api_key="test", ssh_key_file="test_key")
+        pr = config.PrTemplate()
+        cfg = config.Config(
+            credentials=credentials,
+            pr=pr,
+            custom_repos_dir="${TEST_CUSTOM_REPOS_DIR}",
+        )
+        workdir.write_config(wd, cfg)
+
+        # Read it back and verify expansion happened
+        loaded_cfg = workdir.read_config(wd)
+        assert loaded_cfg.custom_repos_dir == str(custom_repos_base)
+    finally:
+        del os.environ["TEST_CUSTOM_REPOS_DIR"]
+
+
+def test_get_function_with_custom_repos_dir(tmp_path):
+    """Test workdir.get() function with custom_repos_dir parameter"""
+    custom_dir = Path(tmp_path) / "custom-repos"
+    custom_dir.mkdir()
+
+    wd = workdir.get(str(tmp_path), custom_repos_dir=custom_dir)
+    assert wd.repos_dir == custom_dir
+
+
+def test_get_function_without_custom_repos_dir(tmp_path):
+    """Test workdir.get() function without custom_repos_dir parameter"""
+    wd = workdir.get(str(tmp_path))
+    expected_default = Path(tmp_path) / "repos"
+    assert wd.repos_dir == expected_default
+
+
+def test_init_with_custom_repos_dir_in_config(tmp_path):
+    """Test init with custom_repos_dir specified in config file"""
+    custom_dir = Path(tmp_path) / "custom-repos"
+    custom_dir.mkdir()
+
+    test_key = Path(tmp_path) / "test_key"
+    test_key.touch()
+
+    # First, create config with custom_repos_dir
+    wd_setup = workdir.WorkDir(Path(tmp_path))
+    credentials = config.Credentials(api_key="test", ssh_key_file=str(test_key))
+    pr = config.PrTemplate()
+    cfg = config.Config(
+        credentials=credentials, pr=pr, custom_repos_dir=str(custom_dir)
+    )
+    workdir.write_config(wd_setup, cfg)
+
+    # Now create a fresh WorkDir and init (simulating re-init)
+    wd = workdir.WorkDir(Path(tmp_path))
+
+    # Should not raise since custom_dir exists
+    workdir.init(wd, credentials)
+
+    # Verify repos_dir points to custom dir
+    assert wd.repos_dir == custom_dir
+
+
+def test_init_fails_with_nonexistent_custom_repos_dir_in_config(tmp_path):
+    """Test init fails when custom_repos_dir in config doesn't exist"""
+    nonexistent_dir = Path(tmp_path) / "nonexistent-repos"
+
+    test_key = Path(tmp_path) / "test_key"
+    test_key.touch()
+
+    # Create config with nonexistent custom_repos_dir
+    wd_setup = workdir.WorkDir(Path(tmp_path))
+    credentials = config.Credentials(api_key="test", ssh_key_file=str(test_key))
+    pr = config.PrTemplate()
+    cfg = config.Config(
+        credentials=credentials, pr=pr, custom_repos_dir=str(nonexistent_dir)
+    )
+    workdir.write_config(wd_setup, cfg)
+
+    # Try to init - should fail
+    wd = workdir.WorkDir(Path(tmp_path))
+    with pytest.raises(CliException) as exc_info:
+        workdir.init(wd, credentials)
+
+    assert str(nonexistent_dir) in str(exc_info.value)
+    assert "does not exist" in str(exc_info.value)


### PR DESCRIPTION
This pull request adds support for configuring a custom directory for cloned repositories in auto-pr, allowing users (especially those managing many repositories) to avoid duplicating disk space and to use pre-existing local clones. The feature can be set via both the configuration file and a new CLI option, with clear precedence and robust error handling. The implementation includes thorough tests and updated documentation.

## Custom repository directory support

* Added a `custom_repos_dir` option to the config file (`config.yaml`) and a `--repos-dir` CLI flag, allowing users to specify an existing directory for cloned repositories. The CLI flag takes precedence over the config file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91-R140) [[2]](diffhunk://#diff-5f4ed80c5c1bc27600ba0fd77f221e0deb95036c16fbcd2e53f0f89cd71b5b7aR55-R60) [[3]](diffhunk://#diff-5f4ed80c5c1bc27600ba0fd77f221e0deb95036c16fbcd2e53f0f89cd71b5b7aL63-R72) [[4]](diffhunk://#diff-04d92c4e5318227c63d849d38cb6d4c5b9e7e8c6643203c039a029f1928ab435R17-R21) [[5]](diffhunk://#diff-04d92c4e5318227c63d849d38cb6d4c5b9e7e8c6643203c039a029f1928ab435R33-R67) [[6]](diffhunk://#diff-04d92c4e5318227c63d849d38cb6d4c5b9e7e8c6643203c039a029f1928ab435L112-R149)
* Ensured that environment variables in `custom_repos_dir` are expanded, and provided clear error messages if referenced variables are missing.
* Updated the initialization logic to validate that a custom directory exists (and fail with a clear error if not), while still creating the default directory if no custom one is specified.

## How to test the change

* Added comprehensive unit and integration tests to verify all aspects of the new feature, including CLI/config precedence, environment variable expansion, error handling, and default behaviors. [[1]](diffhunk://#diff-45fa5f8530eb815c0cf606032e587adedb04dc70e59b203535d51c44654cfc4dR282-R425) [[2]](diffhunk://#diff-ee005df9c5286dc46a048ce1255e69912dfb24cce922c5d0f5d8f288d18041d7R1-R208)

## Documentation

* Updated the `README.md` with clear instructions and usage examples for the new configuration options, including important notes for organizations managing many repositories.## Proposed change

## Checklist

-   [x] Tests have been added to verify that the new code works (if possible)
-   [x] Documentation has been updated to reflect changes
-   [x] `CHANGELOG.md` has been updated to reflect changes
