### PR TITLE
DEN-5648: remove pip dependency from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,14 +15,17 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v1
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.10"
-      - name: Install uv
-        run: pip install uv
+
       - name: Build package
         run: uv build
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
   - Supports environment variable expansion with `${VAR_NAME}` syntax
   - Useful for organizations with >1k repositories to avoid duplicating disk space
   - Priority order: CLI flag > config file > default `repos/` subdirectory
-- (breaking )Minimum Python version required changes to 3.10
+- (breaking) Minimum Python version required changes to 3.10
+- Remove pip dependency from publish workflow
+  - Use official `astral-sh/setup-uv` action instead of pip-based uv installation
 
 ## 1.2.0
 


### PR DESCRIPTION
## Proposed change

 - Removes all pip references from the publish workflow
 - Uses official `astral-sh/setup-uv@v7` action instead of pip-based installation
 - Updates `actions/checkout` from `@master` to `@v6` for better version pinning

## How to test the change
Workflow will be tested on next release.

## Checklist

-   [ ] ~Tests have been added to verify that the new code works (if possible)~
-   [ ] ~Documentation has been updated to reflect changes~
-   [x] `CHANGELOG.md` has been updated to reflect changes
