### PR TITLE
DEN-5937: Fix GHSA-752w-5fwx-jx9f: Upgrade PyJWT to 2.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "single-source==0.4.0",
     "cryptography>=45.0.0",
     "urllib3>=2.6.3",
+    "PyJWT>=2.12.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ dependencies = [
     { name = "marshmallow" },
     { name = "marshmallow-dataclass" },
     { name = "pygithub" },
+    { name = "pyjwt" },
     { name = "pyyaml" },
     { name = "single-source" },
     { name = "urllib3" },
@@ -37,6 +38,7 @@ requires-dist = [
     { name = "marshmallow-dataclass", specifier = "==8.7.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pygithub", specifier = "==2.8.1" },
+    { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "pytest-socket", marker = "extra == 'dev'", specifier = ">=0.7.0" },
@@ -652,11 +654,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Upgrades PyJWT from `2.10.1` (vulnerable) to `2.12.1` (patched) to fix [GHSA-752w-5fwx-jx9f](https://github.com/advisories/GHSA-752w-5fwx-jx9f) / CVE-2026-32597 (CVSS 7.5 HIGH)
- PyJWT is a transitive dependency pulled in by `PyGithub`. Added `PyJWT>=2.12.0` as a direct dependency constraint to enforce the minimum patched version
- No code changes required — purely a dependency version bump

## Vulnerability Details

**GHSA-752w-5fwx-jx9f / CVE-2026-32597** — PyJWT accepts unknown `crit` header extensions

PyJWT <= 2.11.0 does not validate the `crit` (Critical) Header Parameter defined in RFC 7515 §4.1.11. When a JWS token contains a `crit` array listing extensions that PyJWT does not understand, the library accepts the token instead of rejecting it, potentially allowing security policy bypass (e.g. MFA enforcement, token binding).

| | |
|---|---|
| **Severity** | HIGH (CVSS 7.5) |
| **Affected** | PyJWT <= 2.11.0 |
| **Fixed** | PyJWT >= 2.12.0 |
| **Dependabot alert** | [#44](https://github.com/getyourguide/auto-pr/security/dependabot/44) |

## Test plan

- [ ] CI passes (existing tests cover PyGithub/JWT usage)
- [ ] Verify `uv.lock` resolves `pyjwt` to `2.12.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)