### PR TITLE
CF-15869: Add Dependabot merge and approve workflows

### DIFF
--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -1,0 +1,17 @@
+name: Dependabot Approve
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    name: Approve PR
+    uses: getyourguide/actions/.github/workflows/dependabot-approve.yml@main
+    with:
+      targets: patch:all,minor:all
+      pr-url: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -2,7 +2,17 @@ name: Dependabot Merge
 
 on:
   workflow_dispatch:
+    inputs:
+      notify_only_merged:
+        description: "Notify only merged and SEC PRs"
+        type: boolean
+        default: true
+        required: false
+
   schedule:
+    # Daily: merge PRs and report only merged (no notifications to support)
+    - cron: "0,30 8 * * Mon-Fri"
+    # Weekly: notify blocked PRs to support (Mondays only)
     - cron: "0 9 * * Mon"
 
 permissions:
@@ -20,6 +30,6 @@ jobs:
     name: Auto merge
     uses: getyourguide/actions/.github/workflows/dependabot-merge.yml@main
     with:
-      slack_channel: "#sec-dependabot-automerge"
-      slack_ping_support: false
+      slack_ping_support: true
+      hide_report_sections: ${{ (github.event.schedule == '0,30 8 * * Mon-Fri' || (github.event_name == 'workflow_dispatch' && inputs.notify_only_merged)) && 'blocked,pending-approval' || '' }}
     secrets: inherit

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -11,7 +11,7 @@ on:
 
   schedule:
     # Daily: merge PRs and report only merged (no notifications to support)
-    - cron: "0,30 8 * * Mon-Fri"
+    - cron: "0 8 * * Mon-Fri"
     # Weekly: notify blocked PRs to support (Mondays only)
     - cron: "0 9 * * Mon"
 
@@ -31,5 +31,5 @@ jobs:
     uses: getyourguide/actions/.github/workflows/dependabot-merge.yml@main
     with:
       slack_ping_support: true
-      hide_report_sections: ${{ (github.event.schedule == '0,30 8 * * Mon-Fri' || (github.event_name == 'workflow_dispatch' && inputs.notify_only_merged)) && 'blocked,pending-approval' || '' }}
+      hide_report_sections: ${{ (github.event.schedule == '0 8 * * Mon-Fri' || (github.event_name == 'workflow_dispatch' && inputs.notify_only_merged)) && 'blocked,pending-approval' || '' }}
     secrets: inherit

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot Merge
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * Mon"
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
+jobs:
+  auto-merge:
+    name: Auto merge
+    uses: getyourguide/actions/.github/workflows/dependabot-merge.yml@main
+    with:
+      slack_channel: "#sec-dependabot-automerge"
+      slack_ping_support: false
+    secrets: inherit


### PR DESCRIPTION
Enables automated Dependabot PR merging and approval for npm dependencies.

Adds two workflows:
- `dependabot-merge.yml`: Auto-merges approved PRs weekly (Mon 9:00 UTC)
- `dependabot-approve.yml`: Auto-approves patch and minor updates

Workflows use standard configuration from actions repository.