### PR TITLE
DEP-6199: upgrade urllib3 to >=2.7.0 to fix decompression-bomb and header-forwarding CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "PyGithub==2.8.1",
     "single-source==0.4.0",
     "cryptography>=45.0.0",
-    "urllib3>=2.6.3",
+    "urllib3>=2.7.0",
     "PyJWT>=2.12.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ requires-dist = [
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = "==82.0.1" },
     { name = "single-source", specifier = "==0.4.0" },
-    { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "wheel", marker = "extra == 'dev'", specifier = ">=0.46.2" },
 ]
 provides-extras = ["dev"]
@@ -930,11 +930,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Jira Tickets: DEP-6199, DEP-6223

Context:
Two HIGH-severity security alerts affect urllib3 2.6.3 in this repository. Both are resolved by upgrading to urllib3 2.7.0.

Work Needed:
- Update minimum version constraint in pyproject.toml from urllib3>=2.6.3 to urllib3>=2.7.0
- Update uv.lock via `uv lock --upgrade-package urllib3`

Implementation Reasoning:
Both CVEs (decompression-bomb bypass in the streaming API and sensitive header forwarding across origins in proxied redirects) are fixed in urllib3 2.7.0. Combining them into a single version bump is the most efficient approach since they affect the same package.